### PR TITLE
【バックエンド】盤面整形・切り抜きの処理を実装する (#3)

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from classify_shogi_piece import mock_classify_pieces
 from firebase import db_operate
 from generate_kifu import mock_generate_kifu
 from my_types import HelloWorldType, IntegerArrayType
-from predict_board import mock_predict_board
+from predict_board import predict_board
 
 app = FastAPI()
 
@@ -50,11 +50,12 @@ async def move_piece(
     array: IntegerArrayType = np.fromstring(contents, np.uint8)
     image: IntegerArrayType = cv2.imdecode(array, cv2.IMREAD_COLOR)
 
-    # 盤面検出
-    board: IntegerArrayType = mock_predict_board(image=image)
+    # 各マス目画像を取得, shape: (マス目の数, マス目の縦幅, マス目の横幅, 色) = (81, 98, 91, 3)
+    square_images: IntegerArrayType = predict_board(image=image)
+    print(square_images.shape)
     # コマ検出
     pieces: IntegerArrayType = mock_classify_pieces(
-        image=board, model_path="./models/shogi_model.pth"
+        image=square_images, model_path="./models/shogi_model.pth"
     )
     # 棋譜生成
     kifu: str = mock_generate_kifu(pieces, is_sente)

--- a/predict_board/clip_squares.py
+++ b/predict_board/clip_squares.py
@@ -13,8 +13,11 @@ BASE_SIZE: Final[int] = 63
 def clip_squares(
     image: IntegerArrayType, corners: IntegerArrayType
 ) -> IntegerArrayType:
-    board_image = get_board_image(image=image, corners=corners)
-    print(board_image)
+    board_image: IntegerArrayType = get_board_image(
+        image=image, corners=corners
+    )
+    squares: IntegerArrayType = get_squares(image=board_image)
+    return squares
 
 
 def get_board_image(
@@ -32,17 +35,45 @@ def get_board_image(
     return result
 
 
-if __name__ == "__main__":
-    image: IntegerArrayType = cv2.imread("./data/test.jpg")
-    board_image: IntegerArrayType = get_board_image(
-        image=image,
-        corners=np.array(
-            [[[758, 606]], [[30, 690]], [[118, 136]], [[610, 110]]]
-        ),
+def get_squares(image: IntegerArrayType) -> IntegerArrayType:
+    width, height, _ = image.shape
+    square_width: int = int(width / 9)
+    square_height: int = int(height / 9)
+
+    squares: IntegerArrayType = np.array(
+        [
+            image[
+                j * square_width : (j + 1) * square_width,
+                i * square_height : (i + 1) * square_height,
+                :,
+            ]
+            for j in range(9)
+            for i in range(9)
+        ]
     )
 
-    print(board_image.shape, board_image.dtype)
+    return squares
 
-    cv2.imshow("corners", board_image)
+
+if __name__ == "__main__":
+    image: IntegerArrayType = cv2.imread("./data/test.jpg")
+    # cornersで検出されたものを登録する
+    corners: IntegerArrayType = np.array(
+        [[[758, 606]], [[30, 690]], [[118, 136]], [[610, 110]]]
+    )
+    board_image: IntegerArrayType = get_board_image(
+        image=image, corners=corners
+    )
+    square_images: IntegerArrayType = clip_squares(
+        image=image, corners=corners
+    )
+
+    print(square_images.shape, square_images.dtype)
+
+    cv2.imshow("board", board_image)
+    cv2.imshow("squares", np.vstack(square_images))
     cv2.waitKey(0)
     cv2.destroyAllWindows()
+
+    cv2.imwrite("./data/board.jpg", board_image)
+    cv2.imwrite("./data/square.jpg", np.vstack(square_images))

--- a/predict_board/clip_squares.py
+++ b/predict_board/clip_squares.py
@@ -1,0 +1,48 @@
+from typing import Any, Final
+
+import cv2
+import numpy as np
+import numpy.typing as npt
+
+IntegerArrayType: Final[Any] = npt.NDArray[np.int_]
+FloatArrayType: Final[Any] = npt.NDArray[np.float_]
+
+BASE_SIZE: Final[int] = 63
+
+
+def clip_squares(
+    image: IntegerArrayType, corners: IntegerArrayType
+) -> IntegerArrayType:
+    board_image = get_board_image(image=image, corners=corners)
+    print(board_image)
+
+
+def get_board_image(
+    image: IntegerArrayType, corners: IntegerArrayType
+) -> IntegerArrayType:
+    width: int = BASE_SIZE * 13
+    height: int = BASE_SIZE * 14
+    transform: FloatArrayType = cv2.getPerspectiveTransform(
+        np.float32(corners),
+        np.float32([[0, 0], [width, 0], [width, height], [0, height]]),
+    )
+    result: IntegerArrayType = cv2.warpPerspective(
+        image, transform, dsize=(width, height)
+    )
+    return result
+
+
+if __name__ == "__main__":
+    image: IntegerArrayType = cv2.imread("./data/test.jpg")
+    board_image: IntegerArrayType = get_board_image(
+        image=image,
+        corners=np.array(
+            [[[758, 606]], [[30, 690]], [[118, 136]], [[610, 110]]]
+        ),
+    )
+
+    print(board_image.shape, board_image.dtype)
+
+    cv2.imshow("corners", board_image)
+    cv2.waitKey(0)
+    cv2.destroyAllWindows()

--- a/predict_board/clip_squares.py
+++ b/predict_board/clip_squares.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
     image: IntegerArrayType = cv2.imread("./data/test.jpg")
     # cornersで検出されたものを登録する
     corners: IntegerArrayType = np.array(
-        [[[758, 606]], [[30, 690]], [[118, 136]], [[610, 110]]]
+        [[[118, 136]], [[610, 110]], [[758, 606]], [[30, 690]]]
     )
     board_image: IntegerArrayType = get_board_image(
         image=image, corners=corners

--- a/predict_board/corners.py
+++ b/predict_board/corners.py
@@ -27,7 +27,11 @@ def detect_corners(image: IntegerArrayType) -> IntegerArrayType:
         selected_area * image.shape[0] / image_processed.shape[0]
     )
 
-    return corners
+    normalize_corners: IntegerArrayType = get_normalize_corners(
+        corners=corners
+    )
+
+    return normalize_corners
 
 
 # 画像サイズ圧縮
@@ -115,6 +119,12 @@ def get_selected_area(areas: List[IntegerArrayType]) -> IntegerArrayType:
         )
         euclidean_distances.append(euclidean_distance)
     return areas[np.argmin(euclidean_distances)]
+
+
+def get_normalize_corners(corners: IntegerArrayType) -> IntegerArrayType:
+    roll: int = -2 * np.argmin([np.linalg.norm(corner) for corner in corners])
+    result: IntegerArrayType = np.roll(corners, roll)
+    return result
 
 
 if __name__ == "__main__":

--- a/predict_board/corners.py
+++ b/predict_board/corners.py
@@ -121,6 +121,8 @@ if __name__ == "__main__":
     image: IntegerArrayType = cv2.imread("./data/test.jpg")
     corners = detect_corners(image)
 
+    print(corners)
+
     # 画像表示
     cv2.drawContours(image, [corners], -1, (0, 255, 0), 2)
     cv2.imshow("corners", image)

--- a/predict_board/main.py
+++ b/predict_board/main.py
@@ -3,8 +3,13 @@ from typing import Any, Final
 import numpy as np
 import numpy.typing as npt
 
+from .clip_squares import clip_squares
+from .corners import detect_corners
+
 IntegerArrayType: Final[Any] = npt.NDArray[np.int_]
 
 
-def mock_predict_board(image: IntegerArrayType) -> IntegerArrayType:
-    return image
+def predict_board(image: IntegerArrayType) -> IntegerArrayType:
+    corners: IntegerArrayType = detect_corners(image=image)
+    square_image: IntegerArrayType = clip_squares(image=image, corners=corners)
+    return square_image

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ exclude =
     __pycache__/
     .tox/
     .venv/
+ignore = E203
 
 [mypy]
 ignore_missing_imports = True


### PR DESCRIPTION
### Issue

[comment]: <> (issue番号を書く)

- #3 

### 作業内容

[comment]: <> (作業内容を書く)
- 盤面の正面向け処理を実装しました
- マス目の切り抜き処理を実装しました。

#### 生画像
![test](https://user-images.githubusercontent.com/49780545/145719265-215a0bd4-be1f-4f57-ac8f-8aecdf89300a.jpg)

#### 盤面画像
![board](https://user-images.githubusercontent.com/49780545/145719308-da3dd0c3-b86e-47b0-a55c-82d43ceac10d.jpg)

#### マス目画像（縦一列に結合）
![square](https://user-images.githubusercontent.com/49780545/145719312-5fe8846e-9b54-4547-942d-82da36358ac1.jpg)


### 備考

[comment]: <> (補足内容などがあれば書く)
```sh
poetry install
poetry shell
# 角の位置をコピーしておく
python predict_board/corners.py
# if __name__ == '__main__'内部に書き込んでから実行
python predict_board/clip_squares.py
```

### commands

[comment]: <> (関連Issueを自動で閉じる)
close #3 
